### PR TITLE
fix: fixed yarn cache restore; added new purge file

### DIFF
--- a/docker/purge
+++ b/docker/purge
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker stop $(docker ps -aq)
+docker rm $(docker ps -aq)
+docker rmi $(docker images -aq)
+docker volume prune
+docker system prune

--- a/docker/purge
+++ b/docker/purge
@@ -2,5 +2,4 @@
 docker stop $(docker ps -aq)
 docker rm $(docker ps -aq)
 docker rmi $(docker images -aq)
-docker volume prune
-docker system prune
+docker system prune --volumes

--- a/docker/run
+++ b/docker/run
@@ -45,6 +45,14 @@ function retrieveYarnCache() {
     RETRIEVE=true
   fi
 
+  # Case #3: sizes of the .yarn-cache.tgz are different in the docker and in the host
+  SIZE1=$(docker run --rm --entrypoint ls ${COMPOSE_PROJECT_NAME}_$SERVICE_NAME:latest -l /opt/cache/.yarn-cache.tgz|awk '{print $5}')
+  SIZE2=$(ls -l $SERVICE_DIR/.yarn-cache.tgz|awk '{print $5}')
+  if [ $SIZE1 != $SIZE2 ]; then
+    RETRIEVE=true
+    echo ".yarn-cache.tgz is different"
+  fi
+
   if [ "$RETRIEVE" = true ]; then
     echo "Retrieving"
     docker run --rm --entrypoint cat ${COMPOSE_PROJECT_NAME}_$SERVICE_NAME:latest /.yarn-cache.tgz > $SERVICE_DIR/.yarn-cache.tgz


### PR DESCRIPTION
I found out that yarn cache restore actually doesn't work (confirmed in 2 projects based on this one).
I added a fix which solve the issue.

I also included `purge` file. Sometime it may be useful to call `docker/purge` to clean everything and start from scratch.