### PR TITLE
Adding --no-verify option to git commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,7 +335,7 @@ const initGit = async answers => {
 const commit = async answers => {
   const options = { cwd: basedir }
   await exec('git add -A', options)
-  await exec('git commit -m "Boilerplate initialization"', options)
+  await exec('git commit --no-verify -m "Boilerplate initialization"', options)
 }
 
 const runYarn = async answers => {


### PR DESCRIPTION
Adding --no-verify option to git commit - `findsecrets` has false positives in yarn.lock