### PR TITLE
Added instructions on how to run the boilerplate on Windows.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,14 +5,14 @@
 1. Install the new [Docker for MAC](http://www.docker.com/products/docker#/mac).
 2. Edit your `/etc/hosts` file. Add the line `127.0.0.1 local.cleverbuild.biz`.
 
-To test if your configuration is correct, run `docker ps`. You should see something like:
+3. To test if your configuration is correct, run `docker ps`. You should see something like:
 
-```
-$ docker ps
-CONTAINER ID        IMAGE
-```
+    ```
+    $ docker ps
+    CONTAINER ID        IMAGE
+    ```
 
-3. You can adjust Docker resource usage clicking on the Docker icon -> Preferences -> Advanced.
+4. You can adjust Docker resource usage clicking on the Docker icon -> Preferences -> Advanced.
 
 If you have troubles, please contact DevOps.
 
@@ -25,7 +25,7 @@ If you have troubles, please contact DevOps.
 
 To test if your configuration is correct, run `docker ps`. You should see something like:
 
-```
+```bash
 $ docker ps
 CONTAINER ID        IMAGE
 ```
@@ -34,4 +34,49 @@ If you have troubles, please contact DevOps.
 
 ## Windows
 
-Windows is not supported. We strongly recommend to setup a development environment in a Linux virtual machine. You can use Vagrant or plain Virtualbox. Ask DevOps for help.
+While it's suboptimal, as tested in October 2018 it's possible to run this Docker stack in Windows.
+
+Tested in Windows 10.
+
+You will need a couple of workarounds for that:
+
+1. Usually you have Git for Windows installed already.
+   It contains Git Bash shell which comes with complete POSIX-compatible environment via MSYS.
+   It will allow you to run `docker/run` script natively, but you must run it with a special environment variable set,
+   which will be explained later.
+2. Hot reloading of the files will not work because Docker for Windows uses different tech for signaling the container
+   and the container by default does not gets notified after changes in the mounted files or directories.
+   People [discussed it in the forums](https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/8)
+   and there's [a separate Python script solution for that](https://github.com/merofeev/docker-windows-volume-watcher).
+3. For Docker for Windows to be able to mount folders for alephbeta docker container stack you need to explicitly enable "disk sharing"
+   for the disk on which the project files are stored.
+   And to do that you need to have a password defined for your Windows user.
+   If you want to retain paswordless login to your workstation after that, you have to google the solution yourself.
+
+So, the whole procedure looks like this:
+
+1. Install Git for Windows.
+2. Install Docker for Windows.
+3. Install Python for Windows.
+4. Clone the repository, enable sharing of the disk containing the repository in Docker parameters. Install NPM dependencies if needed.
+5. Open the project folder using Git Bash, then run the startup script like that:
+
+    ```bash
+    MSYS_NO_PATHCONV=1 docker/run
+    ```
+
+    This will tell Git Bash to correctly process absolute paths inside the `docker/run` Bash script.
+    On Windows you **must** run `docker/run` with `MSYS_NO_PATHCONV=1` inside MSYS2 environment or it will simply not work, as it's a bash script.
+6. To have hot module reloading properly working, you need to enable file watchers using docker-windows-volume-watcher Python package, like this:
+
+    ```bash
+    pip install docker-windows-volume-watcher
+    docker-volume-watcher
+    ```
+
+    Script can be started from any folder, it watches all currently running containers by default. Hot reloading will work *only* while this script is running.
+7. Add `local.cleverbuild.biz 127.0.0.1` to your HOSTS file.
+
+It's possible to install everything inside the virtual machine, either in VirtualBox or in native Hyper-V hypervisor,
+but VirtualBox incurs enormous penalty on performance, and Hyper-V image coredumps randomly.
+Your mileage may vary, though.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ and without obvious errors.
 
 Local prerequisites are minimal, please follow the
 [installation instructions](INSTALL.md) carefully. We support Linux and MacOS;
-Windows users should use a Linux VM. Review your Docker Advanced settings and
-consider to assign more CPUs and more memory to the Docker process to boost
-performance.
+Windows users can use Docker for Windows with several workarounds or use a Linux VM.
+Review your Docker Advanced settings and consider to assign more CPUs and more memory
+to the Docker process to boost performance.
 
 ### Setting up the environment
 


### PR DESCRIPTION
Even if CT officially does not support Windows in its boilerplate, it doesn't mean it's impossible to run the local setup on Windows with almost the same efficiency as on Linux/MacOS.